### PR TITLE
Crit Wound Table + Typos + Style Fixes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -71,6 +71,10 @@
     "WITCHER.StSpd": "Speed",
     "WITCHER.StVigor": "Vigor",
 
+    "WITCHER.Actor.Race": "Race",
+    "WITCHER.Actor.Gender": "Gender",
+    "WITCHER.Actor.Age": "Age",
+
     "WITCHER.Actor.TotalStats": "Total Stats",
 
     "WITCHER.Actor.Stat.Int": "INT",

--- a/module/config.js
+++ b/module/config.js
@@ -102,9 +102,9 @@ witcher.CritDescription = {
 };
 
 witcher.CritModDescription = {
-  SimpleCrackedJaw: { None: "You are at a -2 to Magical Skills & Verbal Combat (Charisma, Persuasion, Seduction, Leadership, Deceit, Social Etiquette and Intimidation.)", Stabilized: "You are at a -1 to Magical Skills & Verbal Combat.", Treated: "You are at a -1 to Magical Skills."},
-  SimpleDisfiguringScar: { None: "You take a -3 to empathic Verbal Combat (Charisma, Persuasion, Deceit, Social Etiquette, and Leadership)", Stabilized: "You take a -1 to emphatic Verbal Combat.", Treated: "You take a -1 to Seduction."},
-  SimpleCrackedRibs: { None: "You take a -2 to BODY. This does not affect health points.", Stabilized: "You are at a -1 to BODY. ", Treated: "You take a -10 to Encumberance."},
+  SimpleCrackedJaw: { None: "You are at a -2 to Magical Skills & Verbal Combat (Charisma, Persuasion, Seduction, Leadership, Deceit, Social Etiquette and Intimidation).", Stabilized: "You are at a -1 to Magical Skills & Verbal Combat.", Treated: "You are at a -1 to Magical Skills."},
+  SimpleDisfiguringScar: { None: "You take a -3 to empathic Verbal Combat (Charisma, Persuasion, Deceit, Social Etiquette, and Leadership).", Stabilized: "You take a -1 to emphatic Verbal Combat.", Treated: "You take a -1 to Seduction."},
+  SimpleCrackedRibs: { None: "You take a -2 to BODY. This does not affect health points.", Stabilized: "You are at a -1 to BODY.", Treated: "You take a -10 to Encumberance."},
   SimpleForeignObject: { None: "Your Recovery and Critical Healing are affected.", Stabilized: "Your Recovery & Critical Healing are halved.", Treated: "You take a -2 to Recovery and a -1 to your Critical Healing."},
   SimpleSprainedArm: { None: "You take a -2 to actions that use the arm.", Stabilized: "You are at a -1 to actions with that arm.", Treated: "You take a -1 to Physique."},
   SimpleSprainedLeg: { None: "You take a -2 to SPD, Dodge/Escape, and Athletics.", Stabilized: "You take a -1 to SPD, Dodge/Escape, and Athletics.", Treated: "You take a -1 to SPD."},

--- a/scripts/TheWitcherTRPG.js
+++ b/scripts/TheWitcherTRPG.js
@@ -17,6 +17,7 @@ async function preloadHandlebarsTemplates(){
         "systems/TheWitcherTRPG/templates/partials/tab-background.html",
         "systems/TheWitcherTRPG/templates/partials/tab-inventory.html",
         "systems/TheWitcherTRPG/templates/partials/tab-magic.html",
+        "systems/TheWitcherTRPG/templates/partials/crit-wounds-table.html",
         "systems/TheWitcherTRPG/templates/partials/substances.html",
         "systems/TheWitcherTRPG/templates/partials/monster-skill-tab.html",
         "systems/TheWitcherTRPG/templates/partials/monster-spell-tab.html",

--- a/styles/character-header.css
+++ b/styles/character-header.css
@@ -154,6 +154,7 @@ input.right-value {
     display: flex;
     width: 230px;
     height: 60px;
+    margin-bottom: 10px;
 }
 
 .char-button-collum {

--- a/styles/character-header.css
+++ b/styles/character-header.css
@@ -7,7 +7,7 @@
     width: 370px;
 }
 .char-bottom-section table td {
-    padding: 0.25em;
+    padding: 0.35em 0.35em 0.35em 0.5em;
 }
 
 .char-stat-title label {

--- a/styles/character-header.css
+++ b/styles/character-header.css
@@ -1,10 +1,13 @@
-.char-flex {
-    display: flex;
-  }
-
 .char-left-sidebar {
     width: 140px;
     flex: none;
+}
+
+.char-bottom-section {
+    width: 370px;
+}
+.char-bottom-section table td {
+    padding: 0.25em;
 }
 
 .char-stat-title label {

--- a/styles/monster-sheet.css
+++ b/styles/monster-sheet.css
@@ -2,6 +2,10 @@
     display: flex;
 }
 
+.monster-sheet-left-column {
+  padding-right: 10px;
+}
+
 .monster-left-sidebar {
   width: 140px;
 }
@@ -47,13 +51,8 @@ input.small {
   height: 18px;
 }
 
-.monster-right-sidebar {
-  margin-left: 10px;
-  flex: 1;
-}
 
 .monster-knowledge {
   margin-top: 10px;
-  width: 515px;
   position: relative;
 }

--- a/styles/monster-sheet.css
+++ b/styles/monster-sheet.css
@@ -3,8 +3,7 @@
 }
 
 .monster-left-sidebar {
-    width: 140px;
-    flex: none;
+  width: 140px;
 }
 
 .monster-stat-title {
@@ -37,8 +36,8 @@ input.small {
 
 .monster-info {
   position: relative;
-  top: -135px;
-  left: 10px;
+  top: 352px;
+  right: 359px;
   width: 250px;
   background-color: silver;
   font-size: 12px;
@@ -54,8 +53,7 @@ input.small {
 }
 
 .monster-knowledge {
+  margin-top: 10px;
   width: 515px;
   position: relative;
-  top: -100px;
-  margin-top: 10px;
 }

--- a/styles/monster-sheet.css
+++ b/styles/monster-sheet.css
@@ -56,3 +56,7 @@ input.small {
   margin-top: 10px;
   position: relative;
 }
+
+.monster-crit-wounds-section {
+  margin-top: 10px;
+}

--- a/styles/system-styles.css
+++ b/styles/system-styles.css
@@ -425,23 +425,6 @@ input.skill-value {
   height: 25px;
 }
 
-.crit-wounds {
-  background-color: red;
-  width: 450px;
-  margin: 5px;
-  border-radius: 10px;
-  padding: 10px;
-  color: white;
-}
-
-.crit-wound-description {
-  margin-top: 10px;
-}
-
-.crit-wound-mod-description {
-  margin-top: 5px;
-}
-
 .weight-value {
   margin: auto;
   width: min-content;
@@ -458,4 +441,28 @@ input.skill-value {
 
 .description {
   margin: 10px;
+}
+
+.crit-wounds {
+  width: 450px;
+  margin: 5px;
+  padding: 10px;
+}
+
+.crit-wounds-table textarea {
+  resize: vertical;
+}
+
+.crit-wound-description {
+  margin-top: 10px;
+}
+
+.crit-wound-mod-description {
+  margin-top: 5px;
+}
+
+.add-crit,
+.delete-crit {
+  margin: 5px;
+  width: 15px;
 }

--- a/styles/tab-background.css
+++ b/styles/tab-background.css
@@ -3,15 +3,6 @@
     border-color: rgba(0, 0, 0, 0.308);
 }
 
-.crit-wounds {
-    background-color: red;
-    width: 450px;
-    margin: 5px;
-    border-radius: 10px;
-    padding: 10px;
-    color: white;
-  }
-
 .lifeEvents {
   margin: 10px;
 }

--- a/template.json
+++ b/template.json
@@ -582,6 +582,18 @@
     },
     "monster": {
       "templates": ["baseActor"],
+      "critWounds": [],
+      "config": {
+        "CritDescription": {},
+        "CritModDescription": {},
+        "CritGravity": {},
+        "CritGravityDefaultEffect": {},
+        "CritMod": {},
+        "CritSimple": {},
+        "CritComplex": {},
+        "CritDifficult": {},
+        "CritDeadly": {}
+      },
       "category": "",
       "threat": "",
       "difficulty": "",

--- a/templates/partials/character-header.html
+++ b/templates/partials/character-header.html
@@ -84,7 +84,7 @@
                 <div class="right-element">
                     <label>{{localize "WITCHER.Actor.Stamina"}} ({{data.derivedStats.sta.max}})</label>
                     <img class="right-image" src="systems/TheWitcherTRPG/assets/images/stamina.png"/>
-                    <input class="right-value" name="data.derivedStats.sta.value" type="number" value="{{data.derivedStats.sta.value}}" max="99" placeholder="0" data-dtype="Number"/>
+                    <input class="right-value" style="bottom:48px;" name="data.derivedStats.sta.value" type="number" value="{{data.derivedStats.sta.value}}" max="99" placeholder="0" data-dtype="Number"/>
                 </div>
             </div>
             <div class=right-row>

--- a/templates/partials/character-header.html
+++ b/templates/partials/character-header.html
@@ -33,19 +33,19 @@
     <table class="char-bottom-section">
         <tbody>
             <tr>
-                <td><b>Race</b></td>
+                <td><b>{{localize "WITCHER.Actor.Race"}}</b></td>
                 <td colspan="3">{{race.name}}</td>
             </tr>
             <tr>
-                <td><b>Gender</b></td>
+                <td><b>{{localize "WITCHER.Actor.Gender"}}</b></td>
                 <td><input name="data.gender" type="text" value="{{data.gender}}" placeholder=""/></td>
-                <td><b>Age</b></td>
+                <td><b>{{localize "WITCHER.Actor.Age"}}</b></td>
                 <td><input class="header-stat" name="data.general.age" type="number" value="{{data.general.age}}" placeholder="0" data-dtype="Number"/></td>
             </tr>
             <tr>
-                <td><b>Profession</b></td>
+                <td><b>{{localize "WITCHER.Profession"}}</b></td>
                 <td>{{profession.name}}</td>
-                <td><b>Origin</b></td>
+                <td><b>{{localize "WITCHER.Homeland"}}</b></td>
                 <td>{{data.general.homeland.value}}</td>
             </tr>
         </tbody>

--- a/templates/partials/character-header.html
+++ b/templates/partials/character-header.html
@@ -30,30 +30,26 @@
             {{/each}}
         </div>
     </div>
-    <div class="flexrow">
-        <div class="char-flex">
-            <label><b>Race</b></label>
-            {{race.name}}
-        </div>
-        <div class="char-flex">
-            <label><b>Gender</b></label>
-            <input name="data.gender" type="text" value="{{data.gender}}" placeholder=""/>
-        </div>
-        <div class="char-flex">
-            <label><b>Age</b></label>
-            <input class="header-stat" name="data.general.age" type="number" value="{{data.general.age}}" placeholder="0" data-dtype="Number"/>
-        </div>
-    </div>
-    <div class="flexrow">
-        <div class="char-flex">
-            <label><b>Profession</b></label>
-            {{profession.name}}
-        </div>
-        <div class="char-flex">
-            <label><b>Origin</b></label>
-            {{data.general.homeland.value}}
-        </div>
-    </div>
+    <table class="char-bottom-section">
+        <tbody>
+            <tr>
+                <td><b>Race</b></td>
+                <td>{{race.name}}</td>
+            </tr>
+            <tr>
+                <td><b>Gender</b></td>
+                <td><input name="data.gender" type="text" value="{{data.gender}}" placeholder=""/></td>
+                <td><b>Age</b></td>
+                <td><input class="header-stat" name="data.general.age" type="number" value="{{data.general.age}}" placeholder="0" data-dtype="Number"/></td>
+            </tr>
+            <tr>
+                <td><b>Profession</b></td>
+                <td>{{profession.name}}</td>
+                <td><b>Origin</b></td>
+                <td>{{data.general.homeland.value}}</td>
+            </tr>
+        </tbody>
+    </table>
 </div>    
 <div class="right-sidebar">
         <div class="right-top">

--- a/templates/partials/character-header.html
+++ b/templates/partials/character-header.html
@@ -34,7 +34,7 @@
         <tbody>
             <tr>
                 <td><b>Race</b></td>
-                <td>{{race.name}}</td>
+                <td colspan="3">{{race.name}}</td>
             </tr>
             <tr>
                 <td><b>Gender</b></td>

--- a/templates/partials/crit-wounds-table.html
+++ b/templates/partials/crit-wounds-table.html
@@ -1,37 +1,41 @@
-<ul>
-    {{#each data.critWounds as |critWound i| }}
-    <li>
-        <input type="hidden" name="data.critWounds.{{i}}.id" type="text" value="{{critWound.id}}" />
-        <select name="data.critWounds.{{i}}.effect">
-            {{#select (lookup this "effect") }}
-            {{#each (lookup ../config "CritSimple") as |critEffect j|}}
-            <option value="{{j}}">Simple - {{critEffect}}</option>
-            {{/each}}
-            {{#each (lookup ../config "CritComplex") as |critEffect j|}}
-            <option value="{{j}}">Complex - {{critEffect}}</option>
-            {{/each}}
-            {{#each (lookup ../config "CritDifficult") as |critEffect j|}}
-            <option value="{{j}}">Difficult - {{critEffect}}</option>
-            {{/each}}
-            {{#each (lookup ../config "CritDeadly") as |critEffect j|}}
-            <option value="{{j}}">Deadly - {{critEffect}}</option>
-            {{/each}}
-            {{/select}}
-        </select>
-        <select name="data.critWounds.{{i}}.mod">
-            {{#select (lookup this "mod") }}
-            {{#each (lookup ../config "CritMod") as |critWoundModifier j|}}
-            <option value="{{j}}">{{critWoundModifier}}</option>
-            {{/each}}
-            {{/select}}
-        </select>
-        <a class="delete-crit"><i class="fas fa-minus" data-id="{{critWound.id}}"></i></a>
-        <br />
-        <div class="crit-wound-description" name="data.critWounds.{{i}}.description" data-id="CritDescription.{{critWound.effect}}">{{lookup ../config.CritDescription critWound.effect}}</div>
-        <br />
-        <div class="crit-wound-mod-description" name="data.critWounds.{{i}}.modDescription" data-id="CritModDescription.{{critWound.effect}}.{{critWound.mod}}">{{lookup (lookup ../config.CritModDescription critWound.effect) critWound.mod}}</div>
-        <br />
-        <textarea rows=1 name="data.critWounds.{{i}}.notes">{{critWound.notes}}</textarea>
-    </li>
-    {{/each}}
-</ul>
+<table class="crit-wounds-table">
+    <tbody>
+        {{#each data.critWounds as |critWound i| }}
+        <tr>
+            <td>
+                <input type="hidden" name="data.critWounds.{{i}}.id" type="text" value="{{critWound.id}}" />
+                <select name="data.critWounds.{{i}}.effect">
+                    {{#select (lookup this "effect") }}
+                    {{#each (lookup ../config "CritSimple") as |critEffect j|}}
+                    <option value="{{j}}">Simple - {{critEffect}}</option>
+                    {{/each}}
+                    {{#each (lookup ../config "CritComplex") as |critEffect j|}}
+                    <option value="{{j}}">Complex - {{critEffect}}</option>
+                    {{/each}}
+                    {{#each (lookup ../config "CritDifficult") as |critEffect j|}}
+                    <option value="{{j}}">Difficult - {{critEffect}}</option>
+                    {{/each}}
+                    {{#each (lookup ../config "CritDeadly") as |critEffect j|}}
+                    <option value="{{j}}">Deadly - {{critEffect}}</option>
+                    {{/each}}
+                    {{/select}}
+                </select>
+                <select name="data.critWounds.{{i}}.mod">
+                    {{#select (lookup this "mod") }}
+                    {{#each (lookup ../config "CritMod") as |critWoundModifier j|}}
+                    <option value="{{j}}">{{critWoundModifier}}</option>
+                    {{/each}}
+                    {{/select}}
+                </select>
+                <a class="delete-crit"><i class="fas fa-trash-alt" data-id="{{critWound.id}}"></i></a>
+                <br />
+                <div class="crit-wound-description" name="data.critWounds.{{i}}.description" data-id="CritDescription.{{critWound.effect}}">{{lookup ../config.CritDescription critWound.effect}}</div>
+                <br />
+                <div class="crit-wound-mod-description" name="data.critWounds.{{i}}.modDescription" data-id="CritModDescription.{{critWound.effect}}.{{critWound.mod}}">{{lookup (lookup ../config.CritModDescription critWound.effect) critWound.mod}}</div>
+                <br />
+                <textarea rows=1 name="data.critWounds.{{i}}.notes">{{critWound.notes}}</textarea>
+            </td>
+        </tr>
+        {{/each}}
+    </tbody>
+</table>

--- a/templates/partials/crit-wounds-table.html
+++ b/templates/partials/crit-wounds-table.html
@@ -1,0 +1,37 @@
+<ul>
+    {{#each data.critWounds as |critWound i| }}
+    <li>
+        <input type="hidden" name="data.critWounds.{{i}}.id" type="text" value="{{critWound.id}}" />
+        <select name="data.critWounds.{{i}}.effect">
+            {{#select (lookup this "effect") }}
+            {{#each (lookup ../config "CritSimple") as |critEffect j|}}
+            <option value="{{j}}">Simple - {{critEffect}}</option>
+            {{/each}}
+            {{#each (lookup ../config "CritComplex") as |critEffect j|}}
+            <option value="{{j}}">Complex - {{critEffect}}</option>
+            {{/each}}
+            {{#each (lookup ../config "CritDifficult") as |critEffect j|}}
+            <option value="{{j}}">Difficult - {{critEffect}}</option>
+            {{/each}}
+            {{#each (lookup ../config "CritDeadly") as |critEffect j|}}
+            <option value="{{j}}">Deadly - {{critEffect}}</option>
+            {{/each}}
+            {{/select}}
+        </select>
+        <select name="data.critWounds.{{i}}.mod">
+            {{#select (lookup this "mod") }}
+            {{#each (lookup ../config "CritMod") as |critWoundModifier j|}}
+            <option value="{{j}}">{{critWoundModifier}}</option>
+            {{/each}}
+            {{/select}}
+        </select>
+        <a class="delete-crit"><i class="fas fa-minus" data-id="{{critWound.id}}"></i></a>
+        <br />
+        <div class="crit-wound-description" name="data.critWounds.{{i}}.description" data-id="CritDescription.{{critWound.effect}}">{{lookup ../config.CritDescription critWound.effect}}</div>
+        <br />
+        <div class="crit-wound-mod-description" name="data.critWounds.{{i}}.modDescription" data-id="CritModDescription.{{critWound.effect}}.{{critWound.mod}}">{{lookup (lookup ../config.CritModDescription critWound.effect) critWound.mod}}</div>
+        <br />
+        <textarea rows=1 name="data.critWounds.{{i}}.notes">{{critWound.notes}}</textarea>
+    </li>
+    {{/each}}
+</ul>

--- a/templates/partials/tab-background.html
+++ b/templates/partials/tab-background.html
@@ -21,43 +21,7 @@
     <div class="flex">
         <div class="crit-wounds">
             <h2>Crit Wounds <a class="add-crit"><i class="fas fa-plus"></i></a></h2>
-            <ul>
-                {{#each data.critWounds as |critWound i| }}
-                <li>
-                    <input type="hidden" name="data.critWounds.{{i}}.id" type="text" value="{{critWound.id}}" />
-                    <select name="data.critWounds.{{i}}.effect">
-                        {{#select (lookup this "effect") }}
-                        {{#each (lookup ../config "CritSimple") as |critEffect j|}}
-                        <option value="{{j}}">Simple - {{critEffect}}</option>
-                        {{/each}}
-                        {{#each (lookup ../config "CritComplex") as |critEffect j|}}
-                        <option value="{{j}}">Complex - {{critEffect}}</option>
-                        {{/each}}
-                        {{#each (lookup ../config "CritDifficult") as |critEffect j|}}
-                        <option value="{{j}}">Difficult - {{critEffect}}</option>
-                        {{/each}}
-                        {{#each (lookup ../config "CritDeadly") as |critEffect j|}}
-                        <option value="{{j}}">Deadly - {{critEffect}}</option>
-                        {{/each}}
-                        {{/select}}
-                    </select>
-                    <select name="data.critWounds.{{i}}.mod">
-                        {{#select (lookup this "mod") }}
-                        {{#each (lookup ../config "CritMod") as |critWoundModifier j|}}
-                        <option value="{{j}}">{{critWoundModifier}}</option>
-                        {{/each}}
-                        {{/select}}
-                    </select>
-                    <a class="delete-crit"><i class="fas fa-minus" data-id="{{critWound.id}}"></i></a>
-                    <br />
-                    <div class="crit-wound-description" name="data.critWounds.{{i}}.description" data-id="CritDescription.{{critWound.effect}}">{{lookup ../config.CritDescription critWound.effect}}</div>
-                    <br />
-                    <div class="crit-wound-mod-description" name="data.critWounds.{{i}}.modDescription" data-id="CritModDescription.{{critWound.effect}}.{{critWound.mod}}">{{lookup (lookup ../config.CritModDescription critWound.effect) critWound.mod}}</div>
-                    <br />
-                    <textarea rows=1 name="data.critWounds.{{i}}.notes">{{critWound.notes}}</textarea>
-                </li>
-                {{/each}}
-            </ul>
+            {{> "systems/TheWitcherTRPG/templates/partials/crit-wounds-table.html"}}
         </div>
     </div>
     <div class="flexcol background">

--- a/templates/partials/tab-profession.html
+++ b/templates/partials/tab-profession.html
@@ -2,7 +2,7 @@
 {{#if profession}}
 <div class="item" data-item-id="{{profession._id}}">
     <h1 class="flex flex-header" >
-        <label>Prefession:</label>
+        <label>Profession:</label>
         <input class="inline-edit" data-field="name" type="text" value="{{profession.name}}" placeholder="Name" />
         <a class="item-delete"><i class="fas fa-trash-alt"></i></a>
     </h1>

--- a/templates/sheets/actor/monster-sheet.html
+++ b/templates/sheets/actor/monster-sheet.html
@@ -241,7 +241,11 @@
                 <input type="text" name="data.susceptibilities" value="{{data.susceptibilities}}" placeholder="" />
                 <label>Senses</label>
                 <input type="text" name="data.senses" value="{{data.senses}}" placeholder="" />
-                
+
+                <div class="monster-crit-wounds-section">
+                    <h2>Crit Wounds <a class="add-crit" data-itemType="note"><i class="fas fa-plus"></i></a></h2>
+                    {{> "systems/TheWitcherTRPG/templates/partials/crit-wounds-table.html"}}
+                </div>
                 <h2>Notes <a class="add-item" data-itemType="note"><i class="fas fa-plus"></i></a></h2>
                 
                 {{#each notes as |note id|}}

--- a/templates/sheets/actor/monster-sheet.html
+++ b/templates/sheets/actor/monster-sheet.html
@@ -132,7 +132,7 @@
         </div>
 
         <div class="monster-knowledge">
-            <label>Commoner Supperstition (Education DC: <input class="skill-value" name="data.commonSkillValue" type="text" value="{{data.commonSkillValue}}" data-dtype="Number"/>)</label>
+            <label>Commoner Superstition (Education DC: <input class="skill-value" name="data.commonSkillValue" type="text" value="{{data.commonSkillValue}}" data-dtype="Number"/>)</label>
             <textarea rows=10 name="data.common">{{data.common}}</textarea>
             <label>Witcher Knowledge (Monster Lore DC: <input class="skill-value" name="data.monsterLoreSkillValue" type="text" value="{{data.monsterLoreSkillValue}}" data-dtype="Number"/>)</label>
             <textarea rows=25 name="data.monsterLore">{{data.monsterLore}}</textarea>

--- a/templates/sheets/actor/monster-sheet.html
+++ b/templates/sheets/actor/monster-sheet.html
@@ -1,5 +1,5 @@
 <div class="flex">
-    <div>
+    <div class="monster-sheet-left-column">
         <h1><input name="name" type="text" value="{{actor.name}}" placeholder="Name" /></h1>
 
         <div class="flex">

--- a/templates/sheets/actor/monster-sheet.html
+++ b/templates/sheets/actor/monster-sheet.html
@@ -120,14 +120,14 @@
                 </div>
                 <div class="flex">
                     <img class="monster-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" />
+                    <table class="monster-info">
+                        <tr><td>Height</td><td><input type="text" name="data.height" value="{{data.height}}"/></td></tr>
+                        <tr><td>Weight</td><td><input type="text" name="data.weight" value="{{data.weight}}"/></td></tr>
+                        <tr><td>Environment</td><td><input type="text" name="data.environment" value="{{data.environment}}"/></td></tr>
+                        <tr><td>Intelligence</td><td><input type="text" name="data.intelligence" value="{{data.intelligence}}"/></td></tr>
+                        <tr><td>Organization</td><td><input type="text" name="data.organization" value="{{data.organization}}"/></td></tr>
+                    </table>
                 </div>
-                <table class="monster-info">
-                    <tr><td>Height</td><td><input type="text" name="data.height" value="{{data.height}}"/></td></tr>
-                    <tr><td>Weight</td><td><input type="text" name="data.weight" value="{{data.weight}}"/></td></tr>
-                    <tr><td>Environment</td><td><input type="text" name="data.environment" value="{{data.environment}}"/></td></tr>
-                    <tr><td>Intelligence</td><td><input type="text" name="data.intelligence" value="{{data.intelligence}}"/></td></tr>
-                    <tr><td>Organization</td><td><input type="text" name="data.organization" value="{{data.organization}}"/></td></tr>
-                </table>
             </div>
         </div>
 


### PR DESCRIPTION
# Features
- Add crit wound table to Monster actor sheet

<img width="510" alt="Screenshot 2021-07-30 at 01 50 17" src="https://user-images.githubusercontent.com/59653547/127540783-cde0f103-3460-47e9-a67a-5c7e095e05ac.png">

- Tweak crit wound table styles
  - Remove red background from crit wound table as it is rather jarring
  - Replace minus icon with trash icon to be consistent with notes
  - Remove bullet point per crit wound

- Ensure superstition box does not overlap with upper content

<img width="780" alt="Screenshot 2021-07-30 at 01 53 53" src="https://user-images.githubusercontent.com/59653547/127541301-2219b3b7-0735-4468-96f7-8fdf07ceae32.png">

- Fix "Superstition" and "Profession" typos

<img width="842" alt="Screenshot 2021-07-30 at 11 21 55" src="https://user-images.githubusercontent.com/59653547/127595109-537d1a23-8ab7-4502-a3e0-01919dccc1f5.png">

- Tweak character sheet styles
  - Stamina figure to align with centre of stopwatch graphic
  - Use table to align character attributes below character art placeholder

# Tickets
- https://github.com/AnthonyMonette/TheWitcherTRPG/issues/17