### PR TITLE
Display profession formatted text

### DIFF
--- a/templates/partials/tab-profession.html
+++ b/templates/partials/tab-profession.html
@@ -27,7 +27,7 @@
                 <label>{{localize "WITCHER.Actor.Profession.Level"}}</label>
                 <input class="inline-edit profession-level" data-field="data.definingSkill.level" type="number" value="{{profession.data.definingSkill.level}}" placeholder=""/>
             </div>
-<textarea class="inline-edit" rows=10 data-field="data.definingSkill.definition"  value="{{profession.data.definingSkill.level}}">{{profession.data.definingSkill.definition}}</textarea>
+            {{editor content=data.profession.data.definingSkill.definition target="data.profession.data.definingSkill.definition" button=true editable=editable}}
         </div>
         <div class="profession-path flexrow">
             <div>
@@ -52,7 +52,7 @@
                         <label>{{localize "WITCHER.Actor.Profession.Level"}}</label>
                         <input class="inline-edit profession-level" data-field="data.skillPath1.skill1.level" type="number" value="{{profession.data.skillPath1.skill1.level}}" placeholder=""/>
                     </div>
-<textarea class="inline-edit" rows=10 data-field="data.skillPath1.skill1.definition" value="{{profession.data.skillPath1.skill1.definition}}">{{profession.data.skillPath1.skill1.definition}}</textarea>
+                    {{editor content=data.profession.data.skillPath1.skill1.definition target="data.profession.data.skillPath1.skill1.definition" button=true editable=editable}}
                 </div>
                 <div class="profession-card first-path">
                     <div class="flex first-path-header profession-display" 
@@ -74,7 +74,7 @@
                         <label>{{localize "WITCHER.Actor.Profession.Level"}}</label>
                         <input class="inline-edit profession-level" data-field="data.skillPath1.skill2.level" type="number" value="{{profession.data.skillPath1.skill2.level}}" placeholder=""/>
                     </div>
-<textarea class="inline-edit" rows=10 data-field="data.skillPath1.skill2.definition" value="{{profession.data.skillPath1.skill2.definition}}">{{profession.data.skillPath1.skill2.definition}}</textarea>
+                    {{editor content=data.profession.data.skillPath1.skill2.definition target="data.profession.data.skillPath1.skill2.definition" button=true editable=editable}}
                 </div>
                 <div class="profession-card first-path">
                     <div class="flex first-path-header profession-display" 
@@ -96,7 +96,7 @@
                         <label>{{localize "WITCHER.Actor.Profession.Level"}}</label>
                         <input class="inline-edit profession-level" data-field="data.skillPath1.skill3.level" type="number" value="{{profession.data.skillPath1.skill3.level}}" placeholder=""/>
                     </div>
-<textarea class="inline-edit" rows=10 data-field="data.skillPath1.skill3.definition" value="{{profession.data.skillPath1.skill3.definition}}">{{profession.data.skillPath1.skill3.definition}}</textarea>
+                    {{editor content=data.profession.data.skillPath1.skill3.definition target="data.profession.data.skillPath1.skill3.definition" button=true editable=editable}}
                 </div>
             </div>
             <div>
@@ -121,7 +121,7 @@
                         <label>{{localize "WITCHER.Actor.Profession.Level"}}</label>
                         <input class="inline-edit profession-level" data-field="data.skillPath2.skill1.level" type="number" value="{{profession.data.skillPath2.skill1.level}}" placeholder=""/>
                     </div>
-<textarea class="inline-edit" rows=10 data-field="data.skillPath2.skill1.definition" value="{{profession.data.skillPath2.skill1.definition}}">{{profession.data.skillPath2.skill1.definition}}</textarea>
+                    {{editor content=data.profession.data.skillPath2.skill1.definition target="data.profession.data.skillPath2.skill1.definition" button=true editable=editable}}
                 </div>
                 <div class="profession-card second-path">
                     <div class="flex second-path-header profession-display" 
@@ -143,7 +143,7 @@
                         <label>{{localize "WITCHER.Actor.Profession.Level"}}</label>
                         <input class="inline-edit profession-level" data-field="data.skillPath2.skill2.level" type="number" value="{{profession.data.skillPath2.skill2.level}}" placeholder=""/>
                     </div>
-<textarea class="inline-edit" rows=10 data-field="data.skillPath2.skill2.definition" value="{{profession.data.skillPath2.skill2.definition}}">{{profession.data.skillPath2.skill2.definition}}</textarea>
+                    {{editor content=data.profession.data.skillPath2.skill2.definition target="data.profession.data.skillPath2.skill2.definition" button=true editable=editable}}
                 </div>
                 <div class="profession-card second-path">
                     <div class="flex second-path-header profession-display" 
@@ -165,7 +165,7 @@
                         <label>{{localize "WITCHER.Actor.Profession.Level"}}</label>
                         <input class="inline-edit profession-level" data-field="data.skillPath2.skill3.level" type="number" value="{{profession.data.skillPath2.skill3.level}}" placeholder=""/>
                     </div>
-<textarea class="inline-edit" rows=10 data-field="data.skillPath2.skill3.definition" value="{{profession.data.skillPath2.skill3.definition}}">{{profession.data.skillPath2.skill3.definition}}</textarea>
+                    {{editor content=data.profession.data.skillPath2.skill3.definition target="data.profession.data.skillPath2.skill3.definition" button=true editable=editable}}
                 </div>
             </div>
             <div>
@@ -190,7 +190,7 @@
                         <label>{{localize "WITCHER.Actor.Profession.Level"}}</label>
                         <input class="inline-edit profession-level" data-field="data.skillPath3.skill1.level" type="number" value="{{profession.data.skillPath3.skill1.level}}" placeholder=""/>
                     </div>
-<textarea class="inline-edit" rows=10 data-field="data.skillPath3.skill1.definition" value="{{profession.data.skillPath3.skill1.definition}}">{{profession.data.skillPath3.skill1.definition}}</textarea>
+                    {{editor content=data.profession.data.skillPath3.skill1.definition target="data.profession.data.skillPath3.skill1.definition" button=true editable=editable}}
                 </div>
                 <div class="profession-card third-path">
                     <div class="flex third-path-header profession-display" 
@@ -212,7 +212,7 @@
                         <label>{{localize "WITCHER.Actor.Profession.Level"}}</label>
                         <input class="inline-edit profession-level" data-field="data.skillPath3.skill2.level" type="number" value="{{profession.data.skillPath3.skill2.level}}" placeholder=""/>
                     </div>
-<textarea class="inline-edit" rows=10 data-field="data.skillPath3.skill2.definition" value="{{profession.data.skillPath3.skill2.definition}}">{{profession.data.skillPath3.skill2.definition}}</textarea>
+                    {{editor content=data.profession.data.skillPath3.skill2.definition target="data.profession.data.skillPath3.skill2.definition" button=true editable=editable}}
                 </div>
                 <div class="profession-card third-path">
                     <div class="flex third-path-header profession-display" 
@@ -234,7 +234,7 @@
                         <label>{{localize "WITCHER.Actor.Profession.Level"}}</label>
                         <input class="inline-edit profession-level" data-field="data.skillPath3.skill3.level" type="number" value="{{profession.data.skillPath3.skill3.level}}" placeholder=""/>
                     </div>
-<textarea class="inline-edit" rows=10 data-field="data.skillPath3.skill3.definition" value="{{profession.data.skillPath3.skill3.definition}}">{{profession.data.skillPath3.skill3.definition}}</textarea>
+                    {{editor content=data.profession.data.skillPath3.skill3.definition target="data.profession.data.skillPath3.skill3.definition" button=true editable=editable}}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Another try for fixing displaing and editing rich text in profession tab. Now one can edit and save skill definitions (this was not working last time).

Fixes #211 #221