### PR TITLE
Added compatibility with the Token Action HUD TheWitcherTRPG module

### DIFF
--- a/module/sheets/WitcherActorSheet.js
+++ b/module/sheets/WitcherActorSheet.js
@@ -2548,4 +2548,9 @@ export default class WitcherActorSheet extends ActorSheet {
     }
     return totalStats;
   }
+
+  /** Do not delete. This method is here to give external modules the possibility to make skill rolls. */
+  async _onSkillRoll(statNum, skillNum) {
+    rollSkillCheck(this.actor, statNum, skillNum);
+  }
 }


### PR DESCRIPTION
This change is necessary to expose a skill roll function to the outside. That is used by the [Token Action HUD TheWitcherTRPG](https://github.com/ortegamarcel/fvtt-token-action-hud-thewitchertrpg) module.