### PR TITLE
Fix for error in case of 0 ammo

### DIFF
--- a/module/sheets/WitcherActorSheet.js
+++ b/module/sheets/WitcherActorSheet.js
@@ -150,8 +150,10 @@ export default class WitcherActorSheet extends ActorSheet {
         if (this[i]["system"][prop]) {
           total += Number(this[i]["system"][prop])
         }
-        else if (this[i]["system"]["system"][prop]) {
-          total += Number(this[i]["system"]["system"][prop])
+        else if (this[i]["system"]["system"]) {
+          if(this[i]["system"]["system"][prop]) {
+            total += Number(this[i]["system"]["system"][prop])
+          }
         }
       }
       return total


### PR DESCRIPTION
Fix for #332 

Checking if ["System"]["System"] exists before checking for ["System"]["System"][prop] fixed access into void